### PR TITLE
Make fake motor prints debug instead of info

### DIFF
--- a/src/fake_motor.rs
+++ b/src/fake_motor.rs
@@ -110,7 +110,7 @@ impl<const N: usize> RawMotorsIO<N> for FakeMotorsIO<N> {
     }
 
     fn set_torque(&mut self, on: [bool; N]) -> Result<()> {
-        log::info!(target: "fake_io::set_torque", "Setting torque to {:?}", on);
+        log::debug!(target: "fake_io::set_torque", "Setting torque to {:?}", on);
 
         for (cur, target, on, torque_on) in izip!(
             &mut self.current_position,
@@ -146,7 +146,7 @@ impl<const N: usize> RawMotorsIO<N> for FakeMotorsIO<N> {
     }
 
     fn set_target_position(&mut self, target_position: [f64; N]) -> Result<()> {
-        log::info!(target: "fake_io::set_target_position", "Setting target_position to {:?}", target_position);
+        log::debug!(target: "fake_io::set_target_position", "Setting target_position to {:?}", target_position);
         self.target_position = target_position;
 
         for (cur, on, target) in izip!(&mut self.current_position, self.torque_on, target_position)
@@ -167,7 +167,7 @@ impl<const N: usize> RawMotorsIO<N> for FakeMotorsIO<N> {
     }
 
     fn set_velocity_limit(&mut self, velocity: [f64; N]) -> Result<()> {
-        log::info!(target: "fake_io::set_velocity_limit", "Setting velocity_limit to {:?}", velocity);
+        log::debug!(target: "fake_io::set_velocity_limit", "Setting velocity_limit to {:?}", velocity);
         self.velocity_limit = velocity;
         Ok(())
     }
@@ -177,7 +177,7 @@ impl<const N: usize> RawMotorsIO<N> for FakeMotorsIO<N> {
     }
 
     fn set_torque_limit(&mut self, torque: [f64; N]) -> Result<()> {
-        log::info!(target: "fake_io::set_torque_limit", "Setting torque_limit to {:?}", torque);
+        log::debug!(target: "fake_io::set_torque_limit", "Setting torque_limit to {:?}", torque);
         self.torque_limit = torque;
         Ok(())
     }
@@ -187,7 +187,7 @@ impl<const N: usize> RawMotorsIO<N> for FakeMotorsIO<N> {
     }
 
     fn set_pid_gains(&mut self, pid: [PID; N]) -> Result<()> {
-        log::info!(target: "fake_io::set_pid_gains", "Setting pid gains to {:?}", pid);
+        log::debug!(target: "fake_io::set_pid_gains", "Setting pid gains to {:?}", pid);
         self.pid = pid;
         Ok(())
     }


### PR DESCRIPTION
This spams a lot if the rust log level is set to info. And these output are not really necessary to the real-time usage. However they might be very informative for debugging, so I propose to change their logging level to debug.